### PR TITLE
Dependencies updates 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,16 @@
   :url "https://github.com/kelveden/clj-wiremock"
   :license {:name "Eclipse Public License - v 1.0"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[cheshire "5.10.2"]
-                 [clj-http "3.12.3"]
-                 [com.github.tomakehurst/wiremock "2.27.2"]
-                 [org.clojure/clojure "1.11.0"]
-                 [org.clojure/tools.logging "1.2.4"]
-                 [org.slf4j/slf4j-api "1.7.36"]]
+  :dependencies [[cheshire "5.13.0"]
+                 [clj-http "3.13.0"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.2"]
+                 [org.wiremock/wiremock "3.11.0"]
+                 [org.clojure/clojure "1.12.0"]
+                 [org.clojure/tools.logging "1.3.0"]
+                 [org.slf4j/slf4j-api "2.0.13"]]
   :jvm-opts ["-Dclojure.spec.check-asserts=true"]
-  :profiles {:dev {:dependencies [[metosin/ring-http-response "0.9.3"]
-                                  [org.slf4j/slf4j-simple "1.7.36"]
+  :profiles {:dev {:dependencies [[metosin/ring-http-response "0.9.5"]
+                                  [org.slf4j/slf4j-simple "2.0.16"]
                                   [slingshot "0.12.2"]]
                    :source-paths ["dev"]
                    :repl-options {:init-ns user}}})

--- a/src/clj_wiremock/server.clj
+++ b/src/clj_wiremock/server.clj
@@ -39,7 +39,7 @@
     (get-in (http/get (admin-url _ "/scenarios") {:as :json}) [:body :scenarios]))
 
   (register-stub! [_ stub-content]
-    (http/post (admin-url _ "/mappings/new")
+    (http/post (admin-url _ "/mappings")
                {:body (json/generate-string (->stub stub-content))}))
 
   (requests [_]

--- a/test/clj_wiremock/test/examples/with_java_interop.clj
+++ b/test/clj_wiremock/test/examples/with_java_interop.clj
@@ -13,7 +13,7 @@
     (try
       (.start wmk-java)
 
-      (http/post (str "http://localhost:" (.port wmk-java) "/__admin/mappings/new")
+      (http/post (str "http://localhost:" (.port wmk-java) "/__admin/mappings")
                  {:body (json/generate-string {:request  {:method :GET :url "/ping"}
                                                :response {:status 200 :body "pong"}})})
 


### PR DESCRIPTION
This pull request includes updates to dependencies and minor adjustments to HTTP endpoint URL in the project for stub registration to due the new Wiremock changes. 

Update Wiremock to latest version to address CVE-2024-8184 & CVE-2024-6763
Bumped deps to most up tom date versions.

Dependency updates:

* [`project.clj`](diffhunk://#diff-274071745a4e2a04b647d79d500537e6dc13eee54f44d0426140026293701d1bL6-R15): Updated several dependencies to newer versions, including `cheshire`, `clj-http`, `jackson-core`, `wiremock`, `clojure`, `tools.logging`, and `slf4j-api`.

HTTP endpoint adjustments:

* [`src/clj_wiremock/server.clj`](diffhunk://#diff-b0ed417982839c68321dfff7fd958e7faf9bc1aedd637cbe70debfe8c20224f9L42-R42): Changed the URL for registering stubs from `/mappings/new` to `/mappings`.
* [`test/clj_wiremock/test/examples/with_java_interop.clj`](diffhunk://#diff-af953b2d2223b6187e410c8dbdf0e637a519152989b8bbf789379f6522215236L16-R16): Adjusted the endpoint URL for registering stubs in the test from `/mappings/new` to `/mappings`.